### PR TITLE
Fix unhashable type slice error

### DIFF
--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -171,8 +171,8 @@ class UrlCam(Camera):
             k: v
             for (k, v) in sorted(
                 list(self._urls.items()), key=lambda k_v: k_v[1]["date"]
-            )
-        }[-self._max_images :]
+            )[-self._max_images :]
+        }
 
         self._pickle_urls()
         return


### PR DESCRIPTION
Fixes:
```
Logger: homeassistant
Source: custom_components/ha_strava/camera.py:169
Integration: Strava Home Assistant (documentation)
First occurred: 19:12:17 (1 occurrences)
Last logged: 19:12:17
Error doing job: Future exception was never retrieved

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/ha_strava/camera.py", line 169, in img_update_handler
    self._urls = {
TypeError: unhashable type: 'slice'
```